### PR TITLE
Add address, email, and logoUrl fields to office DTOs and entity

### DIFF
--- a/src/modules/offices/dto/create-office.dto.ts
+++ b/src/modules/offices/dto/create-office.dto.ts
@@ -38,6 +38,36 @@ export class CreateOfficeDto {
   phoneNumber: string;
 
   @ApiProperty({
+    description: 'Physical address of the office',
+    example: '123 Main St, City, Country',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @ApiProperty({
+    description: 'Contact email for the office',
+    example: 'office@example.com',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @ApiProperty({
+    description: 'URL to the office logo image',
+    example: 'https://example.com/logo.png',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  logoUrl?: string;
+
+  @ApiProperty({
     description: 'Latitude of the office location',
     example: 40.7128,
     required: false,

--- a/src/modules/offices/dto/update-office.dto.ts
+++ b/src/modules/offices/dto/update-office.dto.ts
@@ -1,4 +1,15 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType, PickType } from '@nestjs/swagger';
 import { CreateOfficeDto } from './create-office.dto';
 
-export class UpdateOfficeDto extends PartialType(CreateOfficeDto) {}
+// Only allow updating office profile fields, not admin credentials
+export class UpdateOfficeDto extends PartialType(
+  PickType(CreateOfficeDto, [
+    'name',
+    'phoneNumber',
+    'latitude',
+    'longitude',
+    'address',
+    'email',
+    'logoUrl',
+  ] as const),
+) {}

--- a/src/modules/offices/entities/office.entity.ts
+++ b/src/modules/offices/entities/office.entity.ts
@@ -17,6 +17,15 @@ export class Office extends BasicEntity {
   @Column({ nullable: false })
   phoneNumber: string;
 
+  @Column({ nullable: true })
+  address?: string | null;
+
+  @Column({ nullable: true })
+  email?: string | null;
+
+  @Column({ nullable: true })
+  logoUrl?: string | null;
+
   @OneToOne(() => User, { eager: true })
   @JoinColumn()
   admin: User;

--- a/src/modules/offices/offices.service.ts
+++ b/src/modules/offices/offices.service.ts
@@ -29,6 +29,9 @@ export class OfficesService {
       latitude: createOfficeDto.latitude ?? null,
       longitude: createOfficeDto.longitude ?? null,
       phoneNumber: createOfficeDto.phoneNumber,
+      address: createOfficeDto.address ?? null,
+      email: createOfficeDto.email ?? null,
+      logoUrl: createOfficeDto.logoUrl ?? null,
     });
 
     // Save the office to get an ID
@@ -159,6 +162,14 @@ export class OfficesService {
       office.latitude = updateOfficeDto.latitude;
     if (updateOfficeDto.longitude !== undefined)
       office.longitude = updateOfficeDto.longitude;
+    if (updateOfficeDto.phoneNumber !== undefined)
+      office.phoneNumber = updateOfficeDto.phoneNumber;
+    if (updateOfficeDto.address !== undefined)
+      office.address = updateOfficeDto.address ?? null;
+    if (updateOfficeDto.email !== undefined)
+      office.email = updateOfficeDto.email ?? null;
+    if (updateOfficeDto.logoUrl !== undefined)
+      office.logoUrl = updateOfficeDto.logoUrl ?? null;
 
     await this.entityManager.save(office);
     return await this.findOne(id);


### PR DESCRIPTION
- Updated CreateOfficeDto to include optional address, email, and logoUrl fields with appropriate validation.
- Enhanced UpdateOfficeDto to allow updates for the new fields.
- Modified Office entity to store address, email, and logoUrl as nullable fields.
- Adjusted OfficesService to handle new fields during office creation and updates.