### PR TITLE
Update Office entity to specify varchar lengths for address, email, and logoUrl fields

### DIFF
--- a/src/modules/offices/entities/office.entity.ts
+++ b/src/modules/offices/entities/office.entity.ts
@@ -17,13 +17,13 @@ export class Office extends BasicEntity {
   @Column({ nullable: false })
   phoneNumber: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   address?: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', length: 191, nullable: true })
   email?: string | null;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', length: 255, nullable: true })
   logoUrl?: string | null;
 
   @OneToOne(() => User, { eager: true })


### PR DESCRIPTION
- Changed address, email, and logoUrl fields to have defined varchar lengths (255 for address and logoUrl, 191 for email) while maintaining their nullable status.